### PR TITLE
[SB-1133] Remove postinstall step. Move it to pretest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
     "local": "npm run icon && node --inspect=4006 ./server/server.js",
     "interface": "next ./interface -p 3006",
     "lint": "./node_modules/.bin/eslint --fix '**/**/*{.js,.scss}'",
-    "test": "jest",
+    "test": "yarn run build && jest",
     "icon": "./node_modules/.bin/svgo icon/icon.svg",
     "precommit": "npm run lint",
     "prepush": "npm run lint && npm run test",
-    "heroku-postbuild": "npm run build",
-    "postinstall": "npm run build"
+    "heroku-postbuild": "npm run build"
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.2.1",


### PR DESCRIPTION
@sprucelabsai/engineers

## Description
We really only need to build on heroku or when running our tests. This will save time when devs are rapidly installing dependencies.
This will also make sure the latest build is used when running tests

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
- Run `yarn install` and notice build step does not run
- Run `yarn test` and notice the build step runs
